### PR TITLE
Added the requirement that the 'endsAt' key be set for a Silence obje…

### DIFF
--- a/alertmanager/alert_objects.py
+++ b/alertmanager/alert_objects.py
@@ -258,7 +258,7 @@ class Silence(AlertObject):
 
         """
         valid = True
-        if 'matchers' in self:
+        if 'matchers' in self and 'endsAt' in self:
             if self['matchers'] and isinstance(self['matchers'], list):
                 for matcher in self['matchers']:
                     if not matcher:


### PR DESCRIPTION
Added the requirement that the 'endsAt' key exist in our Silence object. This makes good sense, because if the 'endsAt' key is not present when a Silence is posted to AlertManager it will throw a bad data exception. Let's head that off at the pass and make sure that our users are going in with some semblance of the correct data structure.