### PR TITLE
Fixed an issue that would cause the silence deletion to fail.

### DIFF
--- a/tests/alertmanager_test.py
+++ b/tests/alertmanager_test.py
@@ -1,4 +1,5 @@
 import unittest
+import time
 
 from alertmanager import AlertManager
 from alertmanager import Alert
@@ -50,6 +51,8 @@ class TestAlertManagerMethods(unittest.TestCase):
         self.assertIn('success', result.status)
 
     def test_delete_silence(self):
+        self.a_manager.post_silence(self.silence)
+        time.sleep(2)
         silences = self.a_manager.get_silence()
         for silence in silences['data']:
             if silence['status']['state'] == 'active':


### PR DESCRIPTION
Occasionally was getting an UnboundLocalError because the silence_id variable wasn't being set. This seemed to be due to the fact that the silence created in a previous test was not finished being processed. To combat this, I added a post_silence to the delete_silence test and added a 2 second wait.