### PR TITLE
Add receiver parameter to get_alerts()

### DIFF
--- a/alertmanager/alertmanager.py
+++ b/alertmanager/alertmanager.py
@@ -181,7 +181,7 @@ class AlertManager(object):
             doesn't understand from being passed in a request.
 
         """
-        valid_keys = ['filter', 'silenced', 'inhibited']
+        valid_keys = ['filter', 'silenced', 'inhibited', 'receiver']
         for key in kwargs.keys():
             if key not in valid_keys:
                 raise KeyError('invalid get parameter {}'.format(key))


### PR DESCRIPTION
Add `receiver` as an acceptable query parameter for `get_alerts()`.

Receiver is a valid parameter as shown in the [openapi spec](https://github.com/prometheus/alertmanager/blob/e1492602209b86e0ca6d7671c7353b62a31b897b/api/v2/openapi.yaml#L171)